### PR TITLE
fix(POST): don't fail when a field is null

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -38,7 +38,7 @@ async def message(req):
       return json({"message": "Invalid feedback field"}, status=422)
 
     icon = {'+': '👍 (Sì)', '-': '👎 (No)'}[feedback]
-    escaped = {k: html.escape(req.json.get(k, '-')) for k in fields}
+    escaped = {k: html.escape(req.json.get(k, '-') or '-') for k in fields}
 
     ip = req.headers.get("x-real-ip", "")
 


### PR DESCRIPTION
When a field is `null` from the request, the key still exists, so we default to '-'.

We want to get negative feedbacks with at least one of the fields, that's taken care by the UI.